### PR TITLE
fix(build): Only bump our version number

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -9,7 +9,7 @@ plugins:
 - - "@semantic-release/changelog"
   - changelogTitle: "# ChangeLog"
 - - "@semantic-release/exec"
-  - prepareCmd: "sed -i -e \"s/version = .*/version = \\\"${nextRelease.version}\\\"/\" Cargo.toml"
+  - prepareCmd: "sed -i -e \"s/^version = .*/version = \\\"${nextRelease.version}\\\"/\" Cargo.toml"
 - - "@semantic-release/git"
   - assets: ["CHANGELOG.md", "Cargo.toml", "Cargo.lock"]
 - - "@semantic-release/github"


### PR DESCRIPTION
The `sed` used to bump the version number was too greedy, so if any
dependencies also had the same version number as ours it would get
bumped too.