### PR TITLE
fix(build): Bump node version for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v2
     - name: Setup node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
-        node-version: 13
+        node-version: 14
     - name: Add conventional-commits plugin
       run: npm install conventional-changelog-conventionalcommits @semantic-release/changelog @semantic-release/exec @semantic-release/git
     - name: Release to GitHub


### PR DESCRIPTION
This addresses an incompatibility with the semantic-version plugins